### PR TITLE
Agrega funcionalidad para responder a zonas horarias dadas

### DIFF
--- a/src/main/java/com/example/demo/web/controller/TimeController.java
+++ b/src/main/java/com/example/demo/web/controller/TimeController.java
@@ -2,10 +2,12 @@ package com.example.demo.web.controller;
 
 import com.example.demo.web.controller.dto.ServerResponse;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -19,5 +21,17 @@ public class TimeController {
         return new ServerResponse<>(LocalDateTime.now(ZoneId.of("UTC"))
                 .truncatedTo(ChronoUnit.SECONDS)
                 .format(DateTimeFormatter.ISO_DATE_TIME) + "Z");
+    }
+
+    @GetMapping("/{region}/{zona}")
+    public ServerResponse<String> pedirHora(@PathVariable String region, @PathVariable String zona) {
+
+        var zoneName = String.format("%s/%s", region, zona);
+
+        var content = OffsetDateTime.now(ZoneId.of(zoneName))
+                .truncatedTo(ChronoUnit.SECONDS)
+                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+
+        return new ServerResponse<>(content);
     }
 }

--- a/src/test/java/com/example/demo/web/controller/TimeControllerTest.java
+++ b/src/test/java/com/example/demo/web/controller/TimeControllerTest.java
@@ -4,9 +4,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,5 +25,12 @@ class TimeControllerTest {
         var response = Instant.parse(sut.pedirHora().getRespuesta());
 
         assertThat(response).isCloseTo(Instant.now(), within(1, ChronoUnit.SECONDS));
+    }
+
+    @Test
+    void producesTimeWithTimeZone() {
+        var response = OffsetDateTime.parse(sut.pedirHora("America", "Mexico_City").getRespuesta());
+
+        assertThat(response).isCloseTo(OffsetDateTime.now(ZoneId.of("America/Mexico_City")), within(1, ChronoUnit.SECONDS));
     }
 }


### PR DESCRIPTION
Fixes #9

Se crea endpoint para recibir una zona horaria en el formato región/zona
(por ejemplo America/Mexico_City o Asia/Tokyo)